### PR TITLE
Feature/cors

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "Luciano Soto",
   "devDependencies": {
     "@faker-js/faker": "^10.0.0",
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/http-errors": "^2.0.5",
     "@types/node": "^18.11.9",
@@ -25,6 +26,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
+    "cors": "^2.8.6",
     "express": "^5.1.0",
     "http-errors": "^2.0.1",
     "zod": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      cors:
+        specifier: ^2.8.6
+        version: 2.8.6
       express:
         specifier: ^5.1.0
         version: 5.2.1
@@ -21,6 +24,9 @@ importers:
       '@faker-js/faker':
         specifier: ^10.0.0
         version: 10.4.0
+      '@types/cors':
+        specifier: ^2.8.19
+        version: 2.8.19
       '@types/express':
         specifier: ^5.0.3
         version: 5.0.6
@@ -132,6 +138,9 @@ packages:
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
   '@types/express-serve-static-core@5.1.1':
     resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
@@ -338,6 +347,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -714,6 +727,10 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -1085,6 +1102,10 @@ snapshots:
     dependencies:
       '@types/node': 18.19.130
 
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 18.19.130
+
   '@types/express-serve-static-core@5.1.1':
     dependencies:
       '@types/node': 18.19.130
@@ -1321,6 +1342,11 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   create-require@1.1.1: {}
 
@@ -1731,6 +1757,8 @@ snapshots:
       undefsafe: 2.0.5
 
   normalize-path@3.0.0: {}
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,13 +6,12 @@ import cors from "cors";
 const app = express();
 const PORT = 3000;
 
-app.use(express.json());
-
 app.use(cors({
   origin: "http://localhost:3000",
   methods: ["GET", "POST", "PATCH", "DELETE"],
   allowedHeaders: ["Content-Type", "Authorization"],
 }));
+app.use(express.json());
 
 routerApi(app);
 app.use(errorHandler);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,18 @@
 import express from "express";
 import { routerApi } from "./routes";
 import { errorHandler } from "./middlewares/errorHandler";
+import cors from "cors";
 
 const app = express();
 const PORT = 3000;
 
 app.use(express.json());
+
+app.use(cors({
+  origin: "http://localhost:3000",
+  methods: ["GET", "POST", "PATCH", "DELETE"],
+  allowedHeaders: ["Content-Type", "Authorization"],
+}));
 
 routerApi(app);
 app.use(errorHandler);


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega control de CORS para permitir o restringir orígenes que pueden consumir la API.

## Cambios

- Instala `cors` y `@types/cors`
- Configura `cors` en `app.ts` antes de `express.json()`
- Define orígenes, métodos y headers permitidos

## Tipo de cambio

- [x] Bug fix
- [x] Nueva feature
- [x] Breaking change
- [x] Refactor

## Testing

- [x] Request desde `http://localhost:3000` retorna headers `Access-Control-Allow-Origin`
- [x] Request desde un origen no permitido retorna error de CORS
- [ ] Preflight `OPTIONS` responde correctamente